### PR TITLE
Contract and contract interface are no longer suported in the same code

### DIFF
--- a/contracts/NonFungibleToken.cdc
+++ b/contracts/NonFungibleToken.cdc
@@ -142,7 +142,3 @@ pub contract interface NonFungibleToken {
         }
     }
 }
-
-// Contract to allow the interface to be deployed
-pub contract Dummy {}
- 


### PR DESCRIPTION
See dapperlabs/flow-emulator#98

In the new version of Cadence only one contract or contract interface is supported in one location. 

The file `NonFungibleToken.cdc` contains a dummy contract declaration to allow it to be deployed using the Visual Studio Code extension. Remove it, because it is not needed / valid anymore.

Same as onflow/flow-ft#41

I'll tag this once it's merged
