### PR TITLE
fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ We are still trying to think about how to do token metadata, which is very impor
 
 If you want to test out these contracts, we recommend either testing them
 with the [Flow Playground](https://play.onflow.org) 
-or with the [Visual Studio Code Extension](https://github.com/onflow/cadence/tree/master/tools/vscode-extension).
+or with the [Visual Studio Code Extension](https://github.com/onflow/flow/blob/master/docs/vscode-extension.md#cadence-visual-studio-code-extension).
 
 The steps to follow are:
 1. Deploy `NonFungibleToken.cdc`

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ We are still trying to think about how to do token metadata, which is very impor
 ## How to test the standard
 
 If you want to test out these contracts, we recommend either testing them
-with the [Flow Playground](play.onflow.org) 
+with the [Flow Playground](https://play.onflow.org) 
 or with the [Visual Studio Code Extension](https://github.com/onflow/cadence/tree/master/tools/vscode-extension).
 
 The steps to follow are:


### PR DESCRIPTION
Link was pointing to an internal github resource that does not exist. I changed this link to point directly at https://play.onflow.org/