### PR TITLE
Allow purchases from `ExampleNFT` contract

### DIFF
--- a/flow.json
+++ b/flow.json
@@ -14,9 +14,16 @@
         "mainnet": "0x1d7e57aa55817448"
       }
     },
+    "FungibleToken": {
+      "source": "./contracts/utility/FungibleToken.cdc",
+      "aliases": {
+        "emulator": "0xee82856bf20e2aa6",
+        "testnet": "0x9a0766d93b6608b7",
+        "mainnet": "0xf233dcee88fe0abe"
+      }
+    },
     "MetadataViews": "./contracts/MetadataViews.cdc",
     "ExampleNFT": "./contracts/ExampleNFT.cdc",
-    "FungibleToken": "./contracts/utility/FungibleToken.cdc",
     "NFTForwarding": "./contracts/utility/NFTForwarding.cdc"
   },
   "networks": {
@@ -36,7 +43,6 @@
         "NonFungibleToken",
         "ExampleNFT",
         "MetadataViews",
-        "FungibleToken",
         "NFTForwarding"
       ]
     }

--- a/scripts/borrow_nft.cdc
+++ b/scripts/borrow_nft.cdc
@@ -1,5 +1,5 @@
-import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
-import ExampleNFT from "../../contracts/ExampleNFT.cdc"
+import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
+import ExampleNFT from "../contracts/ExampleNFT.cdc"
 
 // This script borrows an NFT from a collection
 pub fun main(address: Address, id: UInt64) {

--- a/scripts/get_collection_ids.cdc
+++ b/scripts/get_collection_ids.cdc
@@ -1,13 +1,13 @@
-import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
-import ExampleNFT from "../../contracts/ExampleNFT.cdc"
+import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
+import ExampleNFT from "../contracts/ExampleNFT.cdc"
 
 /// Script to get NFT IDs in an account's collection
 ///
-pub fun main(address: Address, collectionPublicPath: PublicPath): [UInt64] {
+pub fun main(address: Address): [UInt64] {
     let account = getAccount(address)
 
     let collectionRef = account
-        .getCapability(collectionPublicPath)
+        .getCapability(ExampleNFT.CollectionPublicPath)
         .borrow<&{NonFungibleToken.CollectionPublic}>()
         ?? panic("Could not borrow capability from public collection at specified path")
 

--- a/scripts/get_collection_length.cdc
+++ b/scripts/get_collection_length.cdc
@@ -1,5 +1,5 @@
-import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
-import ExampleNFT from "../../contracts/ExampleNFT.cdc"
+import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
+import ExampleNFT from "../contracts/ExampleNFT.cdc"
 
 pub fun main(address: Address): Int {
     let account = getAccount(address)
@@ -8,6 +8,6 @@ pub fun main(address: Address): Int {
         .getCapability(ExampleNFT.CollectionPublicPath)
         .borrow<&{NonFungibleToken.CollectionPublic}>()
         ?? panic("Could not borrow capability from public collection")
-    
+
     return collectionRef.getIDs().length
 }

--- a/scripts/get_nft_metadata.cdc
+++ b/scripts/get_nft_metadata.cdc
@@ -1,5 +1,5 @@
-import ExampleNFT from "../../contracts/ExampleNFT.cdc"
-import MetadataViews from "../../contracts/MetadataViews.cdc"
+import ExampleNFT from "../contracts/ExampleNFT.cdc"
+import MetadataViews from "../contracts/MetadataViews.cdc"
 
 /// This script gets all the view-based metadata associated with the specified NFT
 /// and returns it as a single struct

--- a/scripts/get_nft_view.cdc
+++ b/scripts/get_nft_view.cdc
@@ -1,5 +1,5 @@
-import ExampleNFT from "../../contracts/ExampleNFT.cdc"
-import MetadataViews from "../../contracts/MetadataViews.cdc"
+import ExampleNFT from "../contracts/ExampleNFT.cdc"
+import MetadataViews from "../contracts/MetadataViews.cdc"
 
 pub struct NFTView {
     pub let id: UInt64

--- a/scripts/get_total_supply.cdc
+++ b/scripts/get_total_supply.cdc
@@ -1,4 +1,4 @@
-import ExampleNFT from "../../contracts/ExampleNFT.cdc"
+import ExampleNFT from "../contracts/ExampleNFT.cdc"
 
 pub fun main(): UInt64 {
     return ExampleNFT.totalSupply

--- a/transactions/NFTForwarding/change_forwarder_recipient.cdc
+++ b/transactions/NFTForwarding/change_forwarder_recipient.cdc
@@ -1,6 +1,6 @@
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import ExampleNFT from "../contracts/ExampleNFT.cdc"
-import NFTForwarding from "../contracts/utility/NFTForwarding.cdc"
+import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
+import ExampleNFT from "../../contracts/ExampleNFT.cdc"
+import NFTForwarding from "../../contracts/utility/NFTForwarding.cdc"
 
 /// This transaction is what an account would run
 /// to change the NFTForwarder recipient

--- a/transactions/NFTForwarding/create_forwarder.cdc
+++ b/transactions/NFTForwarding/create_forwarder.cdc
@@ -1,7 +1,7 @@
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import MetadataViews from "../contracts/MetadataViews.cdc"
-import ExampleNFT from "../contracts/ExampleNFT.cdc"
-import NFTForwarding from "../contracts/utility/NFTForwarding.cdc"
+import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
+import MetadataViews from "../../contracts/MetadataViews.cdc"
+import ExampleNFT from "../../contracts/ExampleNFT.cdc"
+import NFTForwarding from "../../contracts/utility/NFTForwarding.cdc"
 
 /// This transaction is what an account would run
 /// to set itself up to forward NFTs to a designated

--- a/transactions/NFTForwarding/transfer_nft_to_receiver.cdc
+++ b/transactions/NFTForwarding/transfer_nft_to_receiver.cdc
@@ -1,5 +1,5 @@
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import ExampleNFT from "../contracts/ExampleNFT.cdc"
+import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
+import ExampleNFT from "../../contracts/ExampleNFT.cdc"
 
 /// This transaction is for transferring an NFT from
 /// one account to another using the recipient's Receiver resource

--- a/transactions/NFTForwarding/unlink_forwarder_link_collection.cdc
+++ b/transactions/NFTForwarding/unlink_forwarder_link_collection.cdc
@@ -1,7 +1,7 @@
-import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
-import MetadataViews from "../contracts/MetadataViews.cdc"
-import ExampleNFT from "../contracts/ExampleNFT.cdc"
-import NFTForwarding from "../contracts/utility/NFTForwarding.cdc"
+import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
+import MetadataViews from "../../contracts/MetadataViews.cdc"
+import ExampleNFT from "../../contracts/ExampleNFT.cdc"
+import NFTForwarding from "../../contracts/utility/NFTForwarding.cdc"
 
 /// This transaction is what an account would run
 /// to link a collection to its public storage

--- a/transactions/mint_nft.cdc
+++ b/transactions/mint_nft.cdc
@@ -1,7 +1,7 @@
 import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
 import ExampleNFT from "../contracts/ExampleNFT.cdc"
 import MetadataViews from "../contracts/MetadataViews.cdc"
-import FungibleToken from "./utility/FungibleToken.cdc"
+import FungibleToken from "../contracts/utility/FungibleToken.cdc"
 
 /// This script uses the NFTMinter resource to mint a new NFT
 /// It must be run with the account that has the minter resource
@@ -14,7 +14,7 @@ transaction(
     thumbnail: String,
     cuts: [UFix64],
     royaltyDescriptions: [String],
-    royaltyBeneficiaries: [Address] 
+    royaltyBeneficiaries: [Address]
 ) {
 
     /// local variable for storing the minter reference
@@ -84,4 +84,3 @@ transaction(
         ExampleNFT.totalSupply == self.mintingIDBefore + 1: "The total supply should have been increased by 1"
     }
 }
- 

--- a/transactions/purchase_nft.cdc
+++ b/transactions/purchase_nft.cdc
@@ -1,0 +1,87 @@
+import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
+import ExampleNFT from "../contracts/ExampleNFT.cdc"
+import MetadataViews from "../contracts/MetadataViews.cdc"
+import FungibleToken from "../contracts/utility/FungibleToken.cdc"
+
+/// This script uses the NFTMinter resource to mint a new NFT
+/// It must be run with the account that has the minter resource
+/// stored in /storage/NFTMinter
+
+transaction(
+    name: String,
+    description: String,
+    thumbnail: String,
+    cuts: [UFix64],
+    royaltyDescriptions: [String],
+    royaltyBeneficiaries: [Address]
+) {
+
+    /// Local variable for storing the vault reference, used for paying purchase fees
+    let vault: &FungibleToken.Vault
+
+    /// Reference to the receiver's collection
+    let recipientCollectionRef: &{NonFungibleToken.CollectionPublic}
+
+    /// Previous NFT ID before the transaction executes
+    let mintingIDBefore: UInt64
+
+    prepare(signer: AuthAccount) {
+        self.mintingIDBefore = ExampleNFT.totalSupply
+
+        self.vault = signer.borrow<&FungibleToken.Vault>(
+            from: /storage/flowTokenVault
+        ) ?? panic("Could not borrow FungibleToken.Vault reference!")
+
+        // Borrow the recipient's public NFT collection reference
+        self.recipientCollectionRef = signer
+            .getCapability(ExampleNFT.CollectionPublicPath)
+            .borrow<&{NonFungibleToken.CollectionPublic}>()
+            ?? panic("Could not get receiver reference to the NFT Collection")
+    }
+
+    pre {
+        cuts.length == royaltyDescriptions.length && cuts.length == royaltyBeneficiaries.length: "Array length should be equal for royalty related details"
+    }
+
+    execute {
+
+        // Create the royalty details
+        var count = 0
+        var royalties: [MetadataViews.Royalty] = []
+        while royaltyBeneficiaries.length > count {
+            let beneficiary = royaltyBeneficiaries[count]
+            let beneficiaryCapability = getAccount(beneficiary)
+            .getCapability<&{FungibleToken.Receiver}>(MetadataViews.getRoyaltyReceiverPublicPath())
+
+            // Make sure the royalty capability is valid before minting the NFT
+            if !beneficiaryCapability.check() { panic("Beneficiary capability is not valid!") }
+
+            royalties.append(
+                MetadataViews.Royalty(
+                    receiver: beneficiaryCapability,
+                    cut: cuts[count],
+                    description: royaltyDescriptions[count]
+                )
+            )
+            count = count + 1
+        }
+
+
+        let feeTokens <- self.vault.withdraw(amount: 10.0)
+
+        // Purchase the NFT and deposit it to the recipient's collection
+        ExampleNFT.purchaseNFT(
+            feeTokens: <- feeTokens,
+            recipient: self.recipientCollectionRef,
+            name: name,
+            description: description,
+            thumbnail: thumbnail,
+            royalties: royalties
+        )
+    }
+
+    post {
+        self.recipientCollectionRef.getIDs().contains(self.mintingIDBefore): "The next NFT ID should have been minted and delivered"
+        ExampleNFT.totalSupply == self.mintingIDBefore + 1: "The total supply should have been increased by 1"
+    }
+}

--- a/transactions/setup_account_to_receive_royalty.cdc
+++ b/transactions/setup_account_to_receive_royalty.cdc
@@ -9,8 +9,8 @@
 /// The path used for the public link is a new path that in the future, is expected to receive
 /// and generic token, which could be forwarded to the appropriate vault
 
-import FungibleToken from "../../contracts/FungibleToken.cdc"
-import MetadataViews from "../../contracts/MetadataViews.cdc"
+import FungibleToken from "../contracts/utility/FungibleToken.cdc"
+import MetadataViews from "../contracts/MetadataViews.cdc"
 
 transaction(vaultPath: StoragePath) {
 

--- a/transactions/transfer_flow_tokens.cdc
+++ b/transactions/transfer_flow_tokens.cdc
@@ -1,0 +1,18 @@
+import FungibleToken from 0xee82856bf20e2aa6
+import FlowToken from 0x0ae53cb6e3f42a79
+
+transaction(receiver: Address, amount: UFix64) {
+    prepare(account: AuthAccount) {
+        let flowVault = account.borrow<&FlowToken.Vault>(
+            from: /storage/flowTokenVault
+        ) ?? panic("Could not borrow BlpToken.Vault reference")
+
+        let receiverRef = getAccount(receiver)
+            .getCapability(/public/flowTokenReceiver)
+            .borrow<&FlowToken.Vault{FungibleToken.Receiver}>()
+            ?? panic("Could not borrow FungibleToken.Receiver reference")
+
+        let tokens <- flowVault.withdraw(amount: amount)
+        receiverRef.deposit(from: <- tokens)
+    }
+}


### PR DESCRIPTION
Closes: #???

## Description

- Update import paths for Cadence files after the recent directory restructure,
- Update contract declaration for `FungibleToken` in `flow.json` config file,
- Allow any account to purchase `ExampleNFT` NFTs

## Context

The [ExampleNFT](https://flow-view-source.com/testnet/account/0xa60cf32e8369f919/contract/ExampleNFT) smart contract is already deployed on Testnet, and it is also part of the [NFTCatalog](https://nft-catalog.vercel.app/catalog/testnet/example). However, it is impossible for other Testnet accounts to obtain such NFTs, without a transaction from the account that owns a `ExampleNFT.NFTMinter` resource. This is rather cumbersome, when developers do not have any other means to own an NFT from a smart contract that is present in the `NFTCatalog`. Hence, we added a smart contract function and a corresponding transaction to facilitate this need, by allowing any account to purchase an `ExampleNFT` NFT.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
<!-- Please follow the below standard to update the version in package.json
    - Major if there is a new smart contract introduced.
    - Major if there is a breaking change that is introduced in the existing contract.
    - Minor if there is a new feature addition within the existing smart contracts.
    - Patch if there is a non breaking change in the existing smart contracts.
-->
- [ ] Update the version in package.json when there is a change in the smart contracts