### PR TITLE
add a metadata view to designate an nft as a pack

### DIFF
--- a/contracts/MetadataViews.cdc
+++ b/contracts/MetadataViews.cdc
@@ -695,6 +695,28 @@ pub contract MetadataViews {
         }
     }
 
+    // Taken from GaiaPackNFT https://flow-view-source.com/mainnet/account/0xfdae91e14e960079/contract/GaiaPackNFT
+    // AllDay Packs have a subset of these so it should be safe to use this more verbose set
+    pub enum PackStatus: UInt8 {
+        pub case Sealed
+        pub case RevealRequested
+        pub case Revealed
+        pub case OpenRequested
+        pub case Opened
+    }
+
+    pub struct Pack {
+        pub let status: PackStatus
+
+        pub fun isOpen(): Bool {
+            return self.status == PackStatus.Opened
+        }
+
+        init(_ status: PackStatus) {
+            self.status = status
+        }
+    }
+
     /// Helper to get Traits view in a typesafe way
     ///
     /// @param viewResolver: A reference to the resolver resource

--- a/docs/MetdataViews/MetadataViews_Pack.md
+++ b/docs/MetdataViews/MetadataViews_Pack.md
@@ -1,0 +1,32 @@
+# Struct `Pack`
+
+```cadence
+pub struct Pack {
+    pub let status: PackStatus
+
+}
+```
+
+View to return the status of an nft if it is a pack.
+
+NOTE: **This view should only be supported if it is a pack**
+
+### Initializer
+
+```cadence
+init(_ status: PackStatus)
+```
+
+
+## Functions
+
+### `isOpened()`
+
+```cadence
+pub fun isOpen(): Bool
+```
+Returns a boolean marking whether this pack has been opened or not
+
+Parameters: None
+
+---


### PR DESCRIPTION
Closes: #???

## Description

Some NFTs on Flow are Packs. They can be opened to obtain the contents inside of them, but are largely useless afterwards. Two examples of this are NFL All Day packs, and Gaia NFT Packs. In both of these cases, there isn't a standard metadata view to designate them as opened. Because of that, users are at risk of purchasing a pack they might not know is empty.

This view adds a way to detect if something is a pack, letting marketplaces decide what they should do with that information. Perhaps that just means displaying that the pack is opened, or it could mean disabling trading altogether. 

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
<!-- Please follow the below standard to update the version in package.json
    - Major if there is a new smart contract introduced.
    - Major if there is a breaking change that is introduced in the existing contract.
    - Minor if there is a new feature addition within the existing smart contracts.
    - Patch if there is a non breaking change in the existing smart contracts.
-->
- [ ] Update the version in package.json when there is a change in the smart contracts