### PR TITLE
Fix `ViewResolver` contract file link

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ fungible token switchboard instead.
 
 ## Contract metadata
 
-Now that contract borrowing is released, you can also implement the [Resolver](./contracts/Resolver.cdc) interface on your contract
+Now that contract borrowing is released, you can also implement the [ViewResolver](./contracts/ViewResolver.cdc) interface on your contract
 and resolve views from there. As an example, you might want to allow your contract to resolve NFTCollectionData and NFTCollectionDisplay
 so that platforms do not need to find an NFT that belongs to your contract to get information about how to set up or show your collection.
 


### PR DESCRIPTION
## Description

I noticed this link was outdated.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
<!-- Please follow the below standard to update the version in package.json
    - Major if there is a new smart contract introduced.
    - Major if there is a breaking change that is introduced in the existing contract.
    - Minor if there is a new feature addition within the existing smart contracts.
    - Patch if there is a non breaking change in the existing smart contracts.
-->
- [ ] Update the version in package.json when there is a change in the smart contracts