### PR TITLE
Remove duplicate variable declaration

### DIFF
--- a/transactions/scripts/get_nft_metadata.cdc
+++ b/transactions/scripts/get_nft_metadata.cdc
@@ -128,8 +128,6 @@ access(all) fun main(address: Address, id: UInt64): NFT {
 
     let bridgedMetadata = MetadataViews.getEVMBridgedMetadata(nft)!
 
-    let bridgedMetadata = MetadataViews.getEVMBridgedMetadata(nft)!
-
     return NFT(
         name: display.name,
         description: display.description,


### PR DESCRIPTION
## Description

I found a duplicate variable declaration in some Cadence script:

```
error: cannot redeclare constant: `bridgedMetadata` is already declared
   --> 2230f332d892ed9b87ca31d2f35e06e2eea941a965faafc5deb73b29052941b2:129:8
    |
129 |     let bridgedMetadata = MetadataViews.getEVMBridgedMetadata(nft)!
    |         --------------- previously declared here
   ... 
    |
131 |     let bridgedMetadata = MetadataViews.getEVMBridgedMetadata(nft)!
    |         ^^^^^^^^^^^^^^^
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
<!-- Please follow the below standard to update the version in package.json
    - Major if there is a new smart contract introduced.
    - Major if there is a breaking change that is introduced in the existing contract.
    - Minor if there is a new feature addition within the existing smart contracts.
    - Patch if there is a non breaking change in the existing smart contracts.
-->
- [ ] Update the version in package.json when there is a change in the smart contracts